### PR TITLE
Feat/parallelism to catch currencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 node_modules
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+test:
+	go test -v ./...
+
+buid:
+	go build -o bin/ ./...

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@
 test:
 	go test -v ./...
 
-buid:
+build:
 	go build -o bin/ ./...

--- a/currency/api/currencyApi.go
+++ b/currency/api/currencyApi.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/diegopaniago/go-currency-converter/currency/service"
 	"github.com/diegopaniago/go-currency-converter/settings"
@@ -13,8 +14,8 @@ func GetCurrency(c fiber.Ctx) error {
 		OriginURL: settings.Load().CurrencyApiUrl,
 	})
 	code := c.Params("code")
-	target := c.Params("target")
-	currency, err := currencyProvider.GetCurrency(code, target)
+	targets := c.Query("targets")
+	currency, err := currencyProvider.GetCurrency(code, strings.Split(targets, ","))
 	if err != nil {
 		return c.Status(500).Send([]byte(err.Error()))
 	}

--- a/currency/service/currencyProvider.go
+++ b/currency/service/currencyProvider.go
@@ -12,7 +12,7 @@ import (
 )
 
 type CurrencyProvider interface {
-	GetCurrency(code string, target string) (model.Currency, error)
+	GetCurrency(code string, targets []string) (model.Currency, error)
 }
 
 type CurrencyProviderImpl struct {
@@ -33,7 +33,9 @@ type CotationResponse struct {
 	CreateDate string `json:"create_date"`
 }
 
-func (c CurrencyProviderImpl) GetCurrency(code string, target string) (model.Currency, error) {
+func (c CurrencyProviderImpl) GetCurrency(code string, targets []string) (model.Currency, error) {
+	//TODO: Refact to use goroutines to get all targets at the same time
+	target := strings.Join(targets, ",")
 	url := fmt.Sprintf(c.OriginURL+"/%s-%s", code, target)
 	res, err := http.Get(url)
 	if err != nil {

--- a/currency/service/currencyProvider_test.go
+++ b/currency/service/currencyProvider_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,17 +11,18 @@ import (
 
 func TestGetCurrency(t *testing.T) {
 	tests := []struct {
-		name           string
-		mockResponse   string
-		mockStatusCode int
-		code           string
-		targets        []string
-		expectError    bool
-		expectedResult []model.Currency
+		name                string
+		mockResponse        string
+		mockStatusCode      int
+		code                string
+		targets             []string
+		expectError         bool
+		expectedResult      []model.Currency
+		expectedErrorResult string
 	}{
 		{
 			name:           "Currency Provider should return the currencies",
-			mockResponse:   `[{"code":"USD","codein":"BRL","name":"Dollar/Real","high":"5.20","low":"5.10","varBid":"0.001","pctChange":"0.02","bid":"5.15","ask":"5.16","timestamp":"1609459200","create_date":"2021-01-01 00:00:00"}]`,
+			mockResponse:   "",
 			mockStatusCode: http.StatusOK,
 			code:           "USD",
 			targets:        []string{"BRL", "EUR"},
@@ -50,44 +50,55 @@ func TestGetCurrency(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	name:           "Currency Provider should return error if called with invalid code",
-		// 	mockResponse:   "",
-		// 	mockStatusCode: http.StatusInternalServerError,
-		// 	code:           "USD",
-		// 	targets:        []string{"BRL", "EUR"},
-		// 	expectError:    true,
-		// },
-		// {
-		// 	name:           "Currency Provider should return error if the external api returns with invalid JSON",
-		// 	mockResponse:   `invalid JSON`,
-		// 	mockStatusCode: http.StatusOK,
-		// 	code:           "USD",
-		// 	targets:        []string{"BRL", "EUR"},
-		// 	expectError:    true,
-		// },
+		{
+			name:                "Currency Provider should return error if called with invalid code",
+			mockResponse:        "",
+			mockStatusCode:      http.StatusNotFound,
+			code:                "DOLAR",
+			targets:             []string{"BRL"},
+			expectError:         true,
+			expectedErrorResult: "error fetching currency DOLAR to BRL: 404 Not Found",
+		},
+		{
+			name:                "Currency Provider should return error if the external api returns with invalid JSON",
+			mockResponse:        `invalid JSON`,
+			mockStatusCode:      http.StatusOK,
+			code:                "BRL",
+			targets:             []string{"USD", "EUR"},
+			expectError:         true,
+			expectedErrorResult: "error to unmarshal json: invalid character 'i' looking for beginning of value",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tc.mockStatusCode)
-				w.Write([]byte(tc.mockResponse))
+				if r.URL.Path == "/USD-BRL" {
+					tc.mockResponse = `[{"code":"USD","codein":"BRL","name":"Dollar/Real","high":"5.20","low":"5.10","varBid":"0.001","pctChange":"0.02","bid":"5.15","ask":"5.16","timestamp":"1609459200","create_date":"2021-01-01 00:00:00"}]`
+					w.WriteHeader(tc.mockStatusCode)
+					w.Write([]byte(tc.mockResponse))
+				} else if r.URL.Path == "/USD-EUR" {
+					tc.mockResponse = `[{"code":"USD","codein":"EUR","name":"Dollar/Euro","high":"1.20","low":"1.10","varBid":"0.001","pctChange":"0.02","bid":"5.15","ask":"5.16","timestamp":"1609459200","create_date":"2021-01-01 00:00:00"}]`
+					w.WriteHeader(tc.mockStatusCode)
+					w.Write([]byte(tc.mockResponse))
+				} else if tc.expectError {
+					w.WriteHeader(tc.mockStatusCode)
+					w.Write([]byte(tc.mockResponse))
+				}
 			}))
 			defer mockServer.Close()
-
-			fmt.Println("mockServer.URL", mockServer.URL)
-
 			currencyProvider := CurrencyProvider(CurrencyProviderImpl{
 				OriginURL: mockServer.URL,
 			})
+
 			currencies, err := currencyProvider.GetCurrency(tc.code, tc.targets)
 
 			if tc.expectError {
 				assert.Error(t, err)
+				assert.Equal(t, tc.expectedErrorResult, err.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedResult, currencies)
+				assert.ElementsMatch(t, tc.expectedResult, currencies)
 			}
 		})
 	}

--- a/currency/service/currencyProvider_test.go
+++ b/currency/service/currencyProvider_test.go
@@ -1,10 +1,13 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/diegopaniago/go-currency-converter/currency/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCurrency(t *testing.T) {
@@ -13,67 +16,79 @@ func TestGetCurrency(t *testing.T) {
 		mockResponse   string
 		mockStatusCode int
 		code           string
-		target         string
+		targets        []string
 		expectError    bool
-		expectedResult model.Currency
+		expectedResult []model.Currency
 	}{
 		{
-			name:           "Currency Provider should return the currency",
+			name:           "Currency Provider should return the currencies",
 			mockResponse:   `[{"code":"USD","codein":"BRL","name":"Dollar/Real","high":"5.20","low":"5.10","varBid":"0.001","pctChange":"0.02","bid":"5.15","ask":"5.16","timestamp":"1609459200","create_date":"2021-01-01 00:00:00"}]`,
 			mockStatusCode: http.StatusOK,
 			code:           "USD",
-			target:         "BRL",
+			targets:        []string{"BRL", "EUR"},
 			expectError:    false,
-			expectedResult: model.Currency{
-				Code:  "USD",
-				Name:  "Dollar",
-				Price: 1.0000,
-				Exchange: model.Exchange{
-					Code:  "BRL",
-					Name:  "Real",
-					Price: 5.15,
+			expectedResult: []model.Currency{
+				{
+					Code:  "USD",
+					Name:  "Dollar",
+					Price: 1.0000,
+					Exchange: model.Exchange{
+						Code:  "BRL",
+						Name:  "Real",
+						Price: 5.15,
+					},
+				},
+				{
+					Code:  "USD",
+					Name:  "Dollar",
+					Price: 1.0000,
+					Exchange: model.Exchange{
+						Code:  "EUR",
+						Name:  "Euro",
+						Price: 5.15,
+					},
 				},
 			},
 		},
-		{
-			name:           "Currency Provider should return error if called with invalid code",
-			mockResponse:   "",
-			mockStatusCode: http.StatusInternalServerError,
-			code:           "USD",
-			target:         "BRL",
-			expectError:    true,
-		},
-		{
-			name:           "Currency Provider should return error if the external api returns with invalid JSON",
-			mockResponse:   `invalid JSON`,
-			mockStatusCode: http.StatusOK,
-			code:           "USD",
-			target:         "BRL",
-			expectError:    true,
-		},
+		// {
+		// 	name:           "Currency Provider should return error if called with invalid code",
+		// 	mockResponse:   "",
+		// 	mockStatusCode: http.StatusInternalServerError,
+		// 	code:           "USD",
+		// 	targets:        []string{"BRL", "EUR"},
+		// 	expectError:    true,
+		// },
+		// {
+		// 	name:           "Currency Provider should return error if the external api returns with invalid JSON",
+		// 	mockResponse:   `invalid JSON`,
+		// 	mockStatusCode: http.StatusOK,
+		// 	code:           "USD",
+		// 	targets:        []string{"BRL", "EUR"},
+		// 	expectError:    true,
+		// },
 	}
 
 	for _, tc := range tests {
-		// t.Run(tc.name, func(t *testing.T) {
-		// 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 		w.WriteHeader(tc.mockStatusCode)
-		// 		w.Write([]byte(tc.mockResponse))
-		// 	}))
-		// 	defer mockServer.Close()
+		t.Run(tc.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.mockStatusCode)
+				w.Write([]byte(tc.mockResponse))
+			}))
+			defer mockServer.Close()
 
-		// 	fmt.Println("mockServer.URL", mockServer.URL)
+			fmt.Println("mockServer.URL", mockServer.URL)
 
-		// 	currencyProvider := CurrencyProvider(CurrencyProviderImpl{
-		// 		OriginURL: mockServer.URL,
-		// 	})
-		// 	currency, err := currencyProvider.GetCurrency(tc.code, tc.target)
+			currencyProvider := CurrencyProvider(CurrencyProviderImpl{
+				OriginURL: mockServer.URL,
+			})
+			currencies, err := currencyProvider.GetCurrency(tc.code, tc.targets)
 
-		// 	if tc.expectError {
-		// 		assert.Error(t, err)
-		// 	} else {
-		// 		assert.NoError(t, err)
-		// 		assert.Equal(t, tc.expectedResult, currency)
-		// 	}
-		// })
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, currencies)
+			}
+		})
 	}
 }

--- a/currency/service/currencyProvider_test.go
+++ b/currency/service/currencyProvider_test.go
@@ -1,13 +1,10 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/diegopaniago/go-currency-converter/currency/model"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCurrency(t *testing.T) {
@@ -57,26 +54,26 @@ func TestGetCurrency(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tc.mockStatusCode)
-				w.Write([]byte(tc.mockResponse))
-			}))
-			defer mockServer.Close()
+		// t.Run(tc.name, func(t *testing.T) {
+		// 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 		w.WriteHeader(tc.mockStatusCode)
+		// 		w.Write([]byte(tc.mockResponse))
+		// 	}))
+		// 	defer mockServer.Close()
 
-			fmt.Println("mockServer.URL", mockServer.URL)
+		// 	fmt.Println("mockServer.URL", mockServer.URL)
 
-			currencyProvider := CurrencyProvider(CurrencyProviderImpl{
-				OriginURL: mockServer.URL,
-			})
-			currency, err := currencyProvider.GetCurrency(tc.code, tc.target)
+		// 	currencyProvider := CurrencyProvider(CurrencyProviderImpl{
+		// 		OriginURL: mockServer.URL,
+		// 	})
+		// 	currency, err := currencyProvider.GetCurrency(tc.code, tc.target)
 
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedResult, currency)
-			}
-		})
+		// 	if tc.expectError {
+		// 		assert.Error(t, err)
+		// 	} else {
+		// 		assert.NoError(t, err)
+		// 		assert.Equal(t, tc.expectedResult, currency)
+		// 	}
+		// })
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/diegopaniago/go-currency-converter
 
-go 1.22.4
+go 1.23.1
 
 require github.com/stretchr/testify v1.9.0
 

--- a/routes.go
+++ b/routes.go
@@ -11,5 +11,5 @@ func SetupRoutes(app *fiber.App) {
 		return c.Send([]byte("I am alive!"))
 	})
 
-	app.Get("/currency/:code/:target", api.GetCurrency)
+	app.Get("/currency/:code", api.GetCurrency)
 }


### PR DESCRIPTION
Adding go routine to deal with a lot of targets fetching in parallel. 
This will increase the resilience and increase the speed of the endpoint response time.